### PR TITLE
Allow functions (but not operations) to have multiple arguments

### DIFF
--- a/lib/inference/minimal_syntax.ml
+++ b/lib/inference/minimal_syntax.ml
@@ -77,17 +77,17 @@ module Expr = struct
     type t =
       | Variable of Variable.t
       | Let of Variable.t * t * t
-      | Lambda of Variable.t * t
-      | Fix of Variable.t * t
-      (* TODO: syntactically, `fix` can only wrap a lambda - perhaps enforce
-         this? *)
-      | Application of t * t
+      | Lambda of lambda
+      | Fix_lambda of Variable.t * lambda
+      | Application of t * t list
       | Literal of Literal.t
       | If_then_else of t * t * t
       | Operator of t * Operator.t * t
       | Unary_operator of Operator.Unary.t * t
       | Handle of handler * t
     [@@deriving sexp]
+
+    and lambda = Variable.t list * t [@@deriving sexp]
 
     and handler =
       { operations : op_handler Variable.Map.t

--- a/lib/inference/minimal_syntax.mli
+++ b/lib/inference/minimal_syntax.mli
@@ -54,17 +54,17 @@ module Expr : sig
   type t =
     | Variable of Variable.t
     | Let of Variable.t * t * t
-    | Lambda of Variable.t * t
-    | Fix of Variable.t * t
-    (* TODO: syntactically, `fix` can only wrap a lambda - perhaps enforce
-       this? *)
-    | Application of t * t
+    | Lambda of lambda
+    | Fix_lambda of Variable.t * lambda
+    | Application of t * t list
     | Literal of Literal.t
     | If_then_else of t * t * t
     | Operator of t * Operator.t * t
     | Unary_operator of Operator.Unary.t * t
     | Handle of handler * t (** evaluates its suject under the handler *)
   [@@deriving sexp]
+
+  and lambda = Variable.t list * t [@@deriving sexp]
 
   (** an effect handler *)
   and handler =

--- a/lib/inference/substitution.ml
+++ b/lib/inference/substitution.ml
@@ -153,9 +153,11 @@ and apply_to_mono t = function
   | Type.Mono.Metavariable v ->
     lookup t v |> Option.value ~default:(Type.Mono.Metavariable v)
   | Type.Mono.Primitive p -> Type.Mono.Primitive (apply_to_primitive t p)
-  | Type.Mono.Arrow (t_arg, e, t_result) ->
+  | Type.Mono.Arrow (t_args, e, t_result) ->
     Type.Mono.Arrow
-      (apply_to_mono t t_arg, apply_to_effect t e, apply_to_mono t t_result)
+      ( List.map ~f:(apply_to_mono t) t_args
+      , apply_to_effect t e
+      , apply_to_mono t t_result )
   | Type.Mono.Variable v -> Type.Mono.Variable v
 
 and apply_to_primitive _t = function

--- a/lib/inference/type.mli
+++ b/lib/inference/type.mli
@@ -42,7 +42,7 @@ end
 (** a monotype contains no forall quantifiers *)
 module Mono : sig
   type t =
-    | Arrow of t * Effect.t * t
+    | Arrow of t list * Effect.t * t
     | Variable of Variable.t
     | Metavariable of Metavariable.t
     | Primitive of Primitive.t

--- a/test/inference/test_inference_invalid.ml
+++ b/test/inference/test_inference_invalid.ml
@@ -6,10 +6,10 @@ module E = M.Expr
 let%expect_test "occurs check rejects omega combinator" =
   let expr =
     E.Lambda
-      ( M.Variable.of_string "x"
+      ( [ M.Variable.of_string "x" ]
       , E.Application
           ( E.Variable (M.Variable.of_string "x")
-          , E.Variable (M.Variable.of_string "x") ) )
+          , [ E.Variable (M.Variable.of_string "x") ] ) )
   in
   Util.print_expr_inference_result expr;
   [%expect
@@ -20,7 +20,7 @@ let%expect_test "occurs check rejects omega combinator" =
         "cannot unify\
        \n(Metavariable a0)\
        \nwith\
-       \n(Arrow (Metavariable a0) (Metavariable e0) (Metavariable a2))\
+       \n(Arrow ((Metavariable a0)) (Metavariable e0) (Metavariable a2))\
        \n")
       (location ()))) |}]
 ;;
@@ -42,30 +42,6 @@ let%expect_test "if statement's branches must have the same type" =
                                  \nwith\
                                  \nUnit\
                                  \n")
-      (location ()))) |}]
-;;
-
-let%expect_test "cannot take fixed point of non function" =
-  let expr =
-    (* `fix x. x + 1` *)
-    let x = M.Variable.of_string "x" in
-    E.Fix
-      ( x
-      , E.Operator
-          ( E.Variable x
-          , M.Operator.Int M.Operator.Int.Plus
-          , E.Literal (M.Literal.Int 1) ) )
-  in
-  Util.print_expr_inference_result expr;
-  [%expect {|
-    (Error
-     ((kind Type_error)
-      (message
-        "cannot unify\
-       \n(Arrow (Metavariable a0) (Metavariable e0) (Metavariable a2))\
-       \nwith\
-       \n(Primitive Int)\
-       \n")
       (location ()))) |}]
 ;;
 


### PR DESCRIPTION
This extends HM inference for functions with lists of arguments. It requires forcing `fix` to only wrap lambdas (which was a hidden assumption anyway) so that we know the argument count of the function it wraps when we check it. 

Xie & Leijen's monadic translation assumes all operations have same number of arguments. This _appears_ fairly easy to rectify, but I won't attempt it for now.