### PR TITLE
Unbox int, bool and unit

### DIFF
--- a/lib/code-generation/helpers.ml
+++ b/lib/code-generation/helpers.ml
@@ -70,6 +70,30 @@ let bool_of_i1 b =
   Codegen.use_builder (Llvm.build_zext b bool "bool")
 ;;
 
+let cast_unboxed_int_of_opaque p name =
+  let open Codegen.Let_syntax in
+  let%bind int = Types.int in
+  Codegen.use_builder (Llvm.build_ptrtoint p int name)
+;;
+
+let cast_unboxed_bool_of_opaque p name =
+  let open Codegen.Let_syntax in
+  let%bind bool = Types.bool in
+  Codegen.use_builder (Llvm.build_ptrtoint p bool name)
+;;
+
+let cast_opaque_of_unboxed v =
+  let open Codegen.Let_syntax in
+  let%bind opaque_pointer = Types.opaque_pointer in
+  Codegen.use_builder (Llvm.build_inttoptr v opaque_pointer "unboxed")
+;;
+
+let const_cast_opaque_of_unboxed v =
+  let open Codegen.Let_syntax in
+  let%map opaque_pointer = Types.opaque_pointer in
+  Llvm.const_inttoptr v opaque_pointer
+;;
+
 let heap_allocate t name ~runtime =
   let open Codegen.Let_syntax in
   let size = Llvm.size_of t in
@@ -100,16 +124,6 @@ let heap_store_aux
   heap_store t v name ~runtime
 ;;
 
-let heap_store_int = heap_store_aux Types.int "int"
-let heap_store_bool = heap_store_aux Types.bool "bool"
-
-let heap_store_unit ~runtime =
-  let open Codegen.Let_syntax in
-  let%bind u = const_unit in
-  let%bind type_unit = Types.unit in
-  heap_store type_unit u "unit" ~runtime
-;;
-
 let heap_store_marker = heap_store_aux Types.marker "marker"
 let heap_store_label = heap_store_aux Types.label "label"
 
@@ -131,8 +145,6 @@ let dereference_aux
   dereference ptr t name
 ;;
 
-let dereference_int = dereference_aux Types.int "int"
-let dereference_bool = dereference_aux Types.bool "bool"
 let dereference_marker = dereference_aux Types.marker "marker"
 let dereference_label = dereference_aux Types.label "label"
 

--- a/lib/code-generation/helpers.mli
+++ b/lib/code-generation/helpers.mli
@@ -27,6 +27,26 @@ val i1_of_bool : Llvm.llvalue -> Llvm.llvalue Codegen.t
 (** converts an [i1] into a valid [Types.bool] **)
 val bool_of_i1 : Llvm.llvalue -> Llvm.llvalue Codegen.t
 
+(** builds a cast from [Types.opaque_pointer] to a [Types.int] *)
+val cast_unboxed_int_of_opaque
+  :  Llvm.llvalue
+  -> string
+  -> Llvm.llvalue Codegen.t
+
+(** builds a cast from [Types.opaque_pointer] to a [Types.bool] *)
+val cast_unboxed_bool_of_opaque
+  :  Llvm.llvalue
+  -> string
+  -> Llvm.llvalue Codegen.t
+
+(** builds an int to ptr cast from e.g. [Types.int] or [Types.bool] to
+    [Types.opaque_pointer] *)
+val cast_opaque_of_unboxed : Llvm.llvalue -> Llvm.llvalue Codegen.t
+
+(** a constant [Types.opaque_pointer] from a constant e.g. [Types.int] or
+    [Types.bool]*)
+val const_cast_opaque_of_unboxed : Llvm.llvalue -> Llvm.llvalue Codegen.t
+
 (** [heap_allocate t name ~runtime] generates code which allocates space on the
     heap for a [t], and returns a typed pointer to it (a [t*]). [name] is used
     as a stem for register names *)
@@ -46,19 +66,6 @@ val heap_store
   -> runtime:Runtime.t
   -> Llvm.llvalue Codegen.t
 
-(** [heap_store_int i ~runtime] allocates memory to hold a [Types.int] and
-    stores [i] there. It returns the address as a [Types.opaque_pointer] *)
-val heap_store_int : Llvm.llvalue -> runtime:Runtime.t -> Llvm.llvalue Codegen.t
-
-(* TODO: could just allocate [true] and [false] at program start, then reuse
-   those *)
-val heap_store_bool
-  :  Llvm.llvalue
-  -> runtime:Runtime.t
-  -> Llvm.llvalue Codegen.t
-
-val heap_store_unit : runtime:Runtime.t -> Llvm.llvalue Codegen.t
-
 val heap_store_marker
   :  Llvm.llvalue
   -> runtime:Runtime.t
@@ -77,8 +84,6 @@ val dereference
   -> string
   -> Llvm.llvalue Codegen.t
 
-val dereference_int : Llvm.llvalue -> Llvm.llvalue Codegen.t
-val dereference_bool : Llvm.llvalue -> Llvm.llvalue Codegen.t
 val dereference_marker : Llvm.llvalue -> Llvm.llvalue Codegen.t
 val dereference_label : Llvm.llvalue -> Llvm.llvalue Codegen.t
 

--- a/lib/code-generation/types.ml
+++ b/lib/code-generation/types.ml
@@ -7,14 +7,10 @@ let opaque_pointer =
   Llvm.pointer_type i8
 ;;
 
-let bool =
-  (* could use i1 (single bit) but can't allocate that little, nor can an i8*
-     point to it *)
-  Codegen.use_context Llvm.i8_type
-;;
-
+(* bool, int, unit are unboxed, fit directly in [opaque_pointer] *)
+let bool = Codegen.use_context Llvm.i64_type
 let int = Codegen.use_context Llvm.i64_type
-let unit = Codegen.use_context Llvm.i8_type
+let unit = Codegen.use_context Llvm.i64_type
 let marker = Codegen.use_context Llvm.i64_type
 let label = Codegen.use_context Llvm.i64_type
 let variant_tag = Codegen.use_context Llvm.i8_type


### PR DESCRIPTION
This PR changes the representation of primitive types `int`, `bool` and, `unit` from heap allocated boxed types, instead storing them directly in the 64 bits of a `Types.opaque_pointer`.

Due to using a conservative garbage collector, we get away without tags, so `int`s can be the full 64 bits. Using an accurate collector would change this.

- [ ] `label`s and `marker`s can also be unboxed.

Since the monadic translation still wraps all values in `Ctl_pure`, this is not a significant performance improvement, but may become significant if/when bind inlining is implemented