### PR TITLE
Distinguish internal and user errors

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -70,6 +70,7 @@ let compile_to_ir
      with
      | Ok () -> Ok (Ok ())
      | Error codegen_error ->
+       (* codegen errors are not user errors *)
        Or_error.error_string
          [%string "codegen error: %{codegen_error#Koka_zero.Codegen_error}"])
 ;;

--- a/lib/phases/04-code-generation/codegen_error.ml
+++ b/lib/phases/04-code-generation/codegen_error.ml
@@ -8,8 +8,9 @@ module Kind = struct
           phase - essentially a nicer [assert_false] *)
       | Unsupported_feature_error (** features not yet implemented *)
       | Verifier_error (** error reported by llvm verifier *)
-    [@@deriving sexp]
-  end (* disable "fragile-match" for generated code *) [@warning "-4"]
+      | Write_error (** failure to write the .ll file *)
+    [@@deriving sexp_of]
+  end
 
   include T
 
@@ -17,6 +18,7 @@ module Kind = struct
     | Impossible_error -> "impossible error"
     | Unsupported_feature_error -> "unsupported feature"
     | Verifier_error -> "verifier error"
+    | Write_error -> "write error"
   ;;
 end
 
@@ -24,7 +26,7 @@ type t =
   { message : string
   ; kind : Kind.t
   }
-[@@deriving sexp]
+[@@deriving sexp_of]
 
 let impossible_error message = { kind = Kind.Impossible_error; message }
 
@@ -33,6 +35,7 @@ let unsupported_feature_error message =
 ;;
 
 let verifier_error message = { kind = Kind.Verifier_error; message }
+let write_error message = { kind = Kind.Write_error; message }
 let to_string { kind; message } = sprintf "%s: %s" (Kind.to_string kind) message
 
 module Or_codegen_error = struct

--- a/lib/phases/04-code-generation/codegen_error.mli
+++ b/lib/phases/04-code-generation/codegen_error.mli
@@ -1,6 +1,6 @@
 open Core
 
-type t [@@deriving sexp]
+type t [@@deriving sexp_of]
 
 (** reports an error which should have been caught at the type inference stage -
     essentially a nicer [assert false].
@@ -14,6 +14,9 @@ val unsupported_feature_error : string -> t
 (** reports an invaid function/module, with a validation report as its message
 *)
 val verifier_error : string -> t
+
+(** reports failure to write out the .ll file *)
+val write_error : string -> t
 
 val to_string : t -> string
 

--- a/lib/util/static_error.mli
+++ b/lib/util/static_error.mli
@@ -8,6 +8,7 @@ module Or_static_error : sig
 
   val ok_exn : 'a t -> 'a
 
+  include Monad.S with type 'a t := 'a t
   include Monad_utils.S with type 'a t := 'a t
 end
 


### PR DESCRIPTION
Catch exceptions/errors which aren't the fault of the user's code - i.e. runtime is missing / we told clang to write to an unwritable path. Surface these to the user through a separate exit code.

Works towards https://github.com/DanGooding/koka-zero-playground/issues/5