### PR TITLE
Allow reporting run statistics at exit

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -83,6 +83,7 @@ let compile_to_exe
       ~print_constraint_graph
       ~print_eps
       ~koka_zero_config
+      ~enable_run_stats
   =
   let exe_filename =
     match exe_filename with
@@ -120,6 +121,7 @@ let compile_to_exe
         ~exe_filename
         ~config:koka_zero_config
         ~optimise
+        ~enable_run_stats
     in
     Ok ()
 ;;
@@ -226,6 +228,15 @@ module Flags = struct
         "DIR path to libgc include/ and lib/ subdirectories. If excluded, will \
          compile without garbage collection."
   ;;
+
+  let enable_run_stats =
+    flag
+      "-enable-run-stats"
+      no_arg
+      ~doc:
+        "report running-time statistics to the filename in env var \
+         KOKA_WRITE_RUN_STATS"
+  ;;
 end
 
 let command_compile =
@@ -237,7 +248,8 @@ let command_compile =
      and exe_filename = Flags.exe_filename
      and where_to_save_temps = Flags.where_to_save_temps
      and print_constraint_graph = Flags.print_constraint_graph
-     and print_eps = Flags.print_eps in
+     and print_eps = Flags.print_eps
+     and enable_run_stats = Flags.enable_run_stats in
      fun () ->
        let open Result.Let_syntax in
        let%bind koka_zero_config =
@@ -250,7 +262,8 @@ let command_compile =
          ~where_to_save_temps
          ~print_constraint_graph
          ~print_eps
-         ~koka_zero_config)
+         ~koka_zero_config
+         ~enable_run_stats)
 ;;
 
 let command_compile_to_ir =

--- a/lib/koka_zero.mli
+++ b/lib/koka_zero.mli
@@ -52,4 +52,5 @@ val compile_ir_to_exe
   -> config:Koka_zero_config.t
   -> exe_filename:string
   -> optimise:bool
+  -> enable_run_stats:bool
   -> unit Or_error.t

--- a/lib/phases/04-code-generation/compile.ml
+++ b/lib/phases/04-code-generation/compile.ml
@@ -1574,7 +1574,7 @@ let compile_program : EPS.Program.t -> unit Codegen.t =
   in
   let main_start_block = Llvm.entry_block main_function in
   let%bind () = Codegen.use_builder (Llvm.position_at_end main_start_block) in
-  let { Runtime.init; _ } = runtime in
+  let { Runtime.init; on_finish; _ } = runtime in
   let%bind _void =
     Runtime.Function.build_call init ~args:(Array.of_list []) ""
   in
@@ -1587,6 +1587,9 @@ let compile_program : EPS.Program.t -> unit Codegen.t =
       ~outer_symbol:Symbol_name.main
       ~runtime
       ~effect_reprs
+  in
+  let%bind _void =
+    Runtime.Function.build_call on_finish ~args:(Array.of_list []) ""
   in
   (* return 0 *)
   let%bind i32 = Codegen.use_context Llvm.i32_type in

--- a/lib/phases/04-code-generation/runtime.ml
+++ b/lib/phases/04-code-generation/runtime.ml
@@ -13,6 +13,7 @@ type t =
   { init : Function.t
   ; exit : Function.t
   ; exit_with_message : Function.t
+  ; on_finish : Function.t
   ; malloc : Function.t
   ; fresh_marker : Function.t
   ; nil_evidence_vector : Function.t
@@ -53,6 +54,10 @@ let declare =
   let%bind exit_with_message =
     let name = Symbol_name.of_runtime_exn "kkr_exit_with_message" in
     declare_function name void_type [ ptr ]
+  in
+  let%bind on_finish =
+    let name = Symbol_name.of_runtime_exn "kkr_on_finish" in
+    declare_function name void_type []
   in
   let%bind malloc =
     let name = Symbol_name.of_runtime_exn "kkr_malloc" in
@@ -95,6 +100,7 @@ let declare =
   { init
   ; exit
   ; exit_with_message
+  ; on_finish
   ; malloc
   ; fresh_marker
   ; nil_evidence_vector

--- a/lib/phases/04-code-generation/runtime.mli
+++ b/lib/phases/04-code-generation/runtime.mli
@@ -16,6 +16,7 @@ type t =
   { init : Function.t
   ; exit : Function.t
   ; exit_with_message : Function.t
+  ; on_finish : Function.t
   ; malloc : Function.t
   ; fresh_marker : Function.t
   ; nil_evidence_vector : Function.t

--- a/lib/phases/05-clang/compile.ml
+++ b/lib/phases/05-clang/compile.ml
@@ -43,6 +43,7 @@ let compile_ir_to_exe
       ~(config : Koka_zero_config.t)
       ~exe_filename
       ~optimise
+      ~enable_run_stats
   =
   let opt_flag = Option.some_if optimise "-O3" |> Option.to_list in
   let gc_flags, gc_lib =
@@ -57,8 +58,11 @@ let compile_ir_to_exe
         ]
       , [ "-lgc" ] )
   in
+  let run_stats_flags =
+    if enable_run_stats then [ "-DENABLE_RUN_STATS" ] else []
+  in
   let warning_flags = [ "-Wall"; "-Wno-override-module" ] in
-  let flags = warning_flags @ opt_flag @ gc_flags in
+  let flags = warning_flags @ opt_flag @ gc_flags @ run_stats_flags in
   let inputs = [ ir_filename; config.runtime_path ] in
   (* it's important for linking that gc library is listed _after_ user code *)
   let args = flags @ inputs @ gc_lib @ [ "-o"; exe_filename ] in

--- a/lib/phases/05-clang/compile.mli
+++ b/lib/phases/05-clang/compile.mli
@@ -6,4 +6,5 @@ val compile_ir_to_exe
   -> config:Koka_zero_config.t
   -> exe_filename:string
   -> optimise:bool
+  -> enable_run_stats:bool
   -> unit Or_error.t


### PR DESCRIPTION
Add functionality for produced binaries to record their elapsed/user/system time, and write this to a file upon exit.

This is enabled by a compiler flag `-enable-run-stats`, and setting the environment variable `KOKA_WRITE_RUN_STATS` to the target filename.

The runtime also sums up time spent blocking in `read-int` waiting for stdin.