### PR TITLE
Add rewriting optimisations to enable tail-call optimisation

### DIFF
--- a/lib/phases/03-evidence-translation/rewriting/constructor_sinking.ml
+++ b/lib/phases/03-evidence-translation/rewriting/constructor_sinking.ml
@@ -1,0 +1,55 @@
+open! Core
+open! Import
+open Evidence_passing_syntax
+
+let map_branch_body (param, body) ~f = param, f body
+
+let map_branch_body3 (param, param', param'', body) ~f =
+  param, param', param'', f body
+;;
+
+let rec add_pure_at_tail (expr : Expr.t) : Expr.t =
+  match expr with
+  | Let (p, t, subject, body) -> Let (p, t, subject, add_pure_at_tail body)
+  | If_then_else (cond, yes, no) ->
+    If_then_else (cond, add_pure_at_tail yes, add_pure_at_tail no)
+  | Match_ctl { subject; pure_branch; yield_branch } ->
+    let pure_branch = map_branch_body pure_branch ~f:add_pure_at_tail in
+    let yield_branch = map_branch_body3 yield_branch ~f:add_pure_at_tail in
+    Match_ctl { subject; pure_branch; yield_branch }
+  | Match_ctl_pure { subject; pure_branch } ->
+    let pure_branch = map_branch_body pure_branch ~f:add_pure_at_tail in
+    Match_ctl_pure { subject; pure_branch }
+  | Match_op { subject; normal_branch; tail_branch } ->
+    let normal_branch = map_branch_body normal_branch ~f:add_pure_at_tail in
+    let tail_branch = map_branch_body tail_branch ~f:add_pure_at_tail in
+    Match_op { subject; normal_branch; tail_branch }
+  | Fresh_marker | Nil_evidence_vector | Variable _ | Lambda _ | Fix_lambda _
+  | Application (_, _, _)
+  | Literal _
+  | Operator (_, _, _)
+  | Unary_operator (_, _)
+  | Construct_pure _ | Construct_yield _
+  | Markers_equal (_, _)
+  | Effect_label _
+  | Construct_op_normal _
+  | Construct_op_tail _
+  | Construct_handler _
+  | Select_operation (_, _, _)
+  | Cons_evidence_vector _
+  | Lookup_evidence _
+  | Get_evidence_marker _
+  | Get_evidence_handler _
+  | Get_evidence_handler_site_vector _
+  | Impure_built_in _ -> Construct_pure expr
+;;
+
+let sink_pure : Expr.t -> Expr.t Modified.t =
+  Modified.original_for_none (function [@warning "-4"]
+    | Expr.Construct_pure inner ->
+      let inner' = add_pure_at_tail inner in
+      (match (inner' : Expr.t) with
+       | Construct_pure _ -> (* failed to sink `Pure` any further *) None
+       | _ -> Some inner')
+    | _ -> None)
+;;

--- a/lib/phases/03-evidence-translation/rewriting/constructor_sinking.mli
+++ b/lib/phases/03-evidence-translation/rewriting/constructor_sinking.mli
@@ -1,0 +1,6 @@
+open! Core
+open! Import
+open Evidence_passing_syntax
+
+(* For any instance `Construct_pure expr` push the constructor inside any control flow/let-bindings etc. *)
+val sink_pure : Expr.t -> Expr.t Modified.t

--- a/lib/phases/03-evidence-translation/rewriting/identity_match_body.ml
+++ b/lib/phases/03-evidence-translation/rewriting/identity_match_body.ml
@@ -1,0 +1,56 @@
+open! Core
+open! Import
+open Evidence_passing_syntax
+
+let remove_identity_match =
+  Modified.original_for_none (fun expr ->
+    match (expr : Expr.t) with
+    | Match_ctl_pure { subject; pure_branch = x, Construct_pure (Variable x') }
+      when [%equal: Variable.t] x x' -> Some subject
+    | Match_ctl_pure _ -> None
+    | Match_ctl
+        { subject
+        ; pure_branch = x, Construct_pure (Variable x')
+        ; yield_branch =
+            ( m
+            , c
+            , k
+            , Construct_yield
+                { marker = Variable m'
+                ; op_clause = Variable c'
+                ; resumption = Variable k'
+                } )
+        }
+      when [%equal: Variable.t * Variable.t * Variable.t * Variable.t]
+             (x, m, c, k)
+             (x', m', c', k') -> Some subject
+    | Match_ctl _ -> None
+    | Match_op
+        { subject
+        ; normal_branch = n, Construct_op_normal (Variable n')
+        ; tail_branch = t, Construct_op_tail (Variable t')
+        }
+      when [%equal: Variable.t * Variable.t] (n, t) (n', t') -> Some subject
+    | Match_op _ -> None
+    | Fresh_marker | Nil_evidence_vector | Variable _
+    | Let (_, _, _, _)
+    | Lambda _ | Fix_lambda _
+    | Application (_, _, _)
+    | Literal _
+    | If_then_else (_, _, _)
+    | Operator (_, _, _)
+    | Unary_operator (_, _)
+    | Construct_pure _ | Construct_yield _
+    | Markers_equal (_, _)
+    | Effect_label _
+    | Construct_op_normal _
+    | Construct_op_tail _
+    | Construct_handler _
+    | Select_operation _
+    | Cons_evidence_vector _
+    | Lookup_evidence _
+    | Get_evidence_marker _
+    | Get_evidence_handler _
+    | Get_evidence_handler_site_vector _
+    | Impure_built_in _ -> None)
+;;

--- a/lib/phases/03-evidence-translation/rewriting/identity_match_body.mli
+++ b/lib/phases/03-evidence-translation/rewriting/identity_match_body.mli
@@ -1,0 +1,6 @@
+open! Core
+open! Import
+open Evidence_passing_syntax
+
+(* Any `match` where each branch's body just reconstructs the subject can be removed. *)
+val remove_identity_match : Expr.t -> Expr.t Modified.t

--- a/lib/phases/03-evidence-translation/rewriting/monad_identify.ml
+++ b/lib/phases/03-evidence-translation/rewriting/monad_identify.ml
@@ -1,0 +1,28 @@
+open! Core
+open! Import
+open Evidence_passing_syntax
+
+let is_name : Expr.t -> Variable.t -> bool =
+  fun e name ->
+  match[@warning "-4"] e with
+  | Expr.Variable v -> Variable.(name = v)
+  | _ -> false
+;;
+
+(** apply the monad law [return e1 >>= (fun y -> e2)] --> [let y = e1 in e2]
+
+    which in the uncurried form is [(Pure e1, evv) >>= (fun y evv' -> e2)] -->
+    [let y = e1 in let evv' = evv in e2] *)
+let left_unit : Expr.t -> Expr.t Modified.t =
+  Modified.original_for_none (function [@warning "-4"]
+    | Expr.Application
+        ( bind
+        , [ (Expr.Construct_pure e1, Ctl)
+          ; (vector, Pure)
+          ; (Expr.Lambda ([ (y, Pure); (vector', Pure) ], Ctl, e2), Pure)
+          ]
+        , Ctl )
+      when is_name bind Primitive_names.bind ->
+      Expr.Let (y, Pure, e1, Expr.Let (vector', Pure, vector, e2)) |> Some
+    | _ -> None)
+;;

--- a/lib/phases/03-evidence-translation/rewriting/monad_identify.mli
+++ b/lib/phases/03-evidence-translation/rewriting/monad_identify.mli
@@ -1,0 +1,5 @@
+open! Core
+open! Import
+open Evidence_passing_syntax
+
+val left_unit : Expr.t -> Expr.t Modified.t

--- a/lib/phases/03-evidence-translation/rewriting/rewriting.ml
+++ b/lib/phases/03-evidence-translation/rewriting/rewriting.ml
@@ -1,37 +1,16 @@
 open! Core
 open! Import
-open Evidence_passing_syntax
 
-let is_name : Expr.t -> Variable.t -> bool =
-  fun e name ->
-  match[@warning "-4"] e with
-  | Expr.Variable v -> Variable.(name = v)
-  | _ -> false
-;;
-
-(** apply the monad law [return e1 >>= (fun y -> e2)] --> [let y = e1 in e2]
-
-    which in the uncurried form is [(Pure e1, evv) >>= (fun y evv' -> e2)] -->
-    [let y = e1 in let evv' = evv in e2] *)
-let left_unit : Expr.t -> Expr.t Modified.t =
-  Modified.original_for_none (function [@warning "-4"]
-    | Expr.Application
-        ( bind
-        , [ (Expr.Construct_pure e1, Ctl)
-          ; (vector, Pure)
-          ; (Expr.Lambda ([ (y, Pure); (vector', Pure) ], Ctl, e2), Pure)
-          ]
-        , Ctl )
-      when is_name bind Primitive_names.bind ->
-      Expr.Let (y, Pure, e1, Expr.Let (vector', Pure, vector, e2)) |> Some
-    | _ -> None)
-;;
-
-let rewrite_program (program : Program.t) =
+let rewrite_program (program : Evidence_passing_syntax.Program.t) =
   let open Generation.Let_syntax in
+  (* bind inlining need only be applied once. *)
   let%map program = Bind_inlining.rewrite_program program in
+  (* other rewrites are applied repeatedly until it stops changing *)
+  let rewrites = [ Monad_identify.left_unit ] in
   Modified.apply_while_changes
-    ~f:(Rewriting_utils.apply_everywhere_to_program ~rewrite:left_unit)
+    ~f:(fun program ->
+      Modified.list_fold rewrites ~init:program ~f:(fun program rewrite ->
+        Rewriting_utils.apply_everywhere_to_program program ~rewrite))
     program
   |> Modified.value
 ;;

--- a/lib/phases/03-evidence-translation/rewriting/rewriting.ml
+++ b/lib/phases/03-evidence-translation/rewriting/rewriting.ml
@@ -6,7 +6,12 @@ let rewrite_program (program : Evidence_passing_syntax.Program.t) =
   (* bind inlining need only be applied once. *)
   let%map program = Bind_inlining.rewrite_program program in
   (* other rewrites are applied repeatedly until it stops changing *)
-  let rewrites = [ Monad_identify.left_unit; Constructor_sinking.sink_pure ] in
+  let rewrites =
+    [ Monad_identify.left_unit
+    ; Constructor_sinking.sink_pure
+    ; Identity_match_body.remove_identity_match
+    ]
+  in
   Modified.apply_while_changes
     ~f:(fun program ->
       Modified.list_fold rewrites ~init:program ~f:(fun program rewrite ->

--- a/lib/phases/03-evidence-translation/rewriting/rewriting.ml
+++ b/lib/phases/03-evidence-translation/rewriting/rewriting.ml
@@ -6,7 +6,7 @@ let rewrite_program (program : Evidence_passing_syntax.Program.t) =
   (* bind inlining need only be applied once. *)
   let%map program = Bind_inlining.rewrite_program program in
   (* other rewrites are applied repeatedly until it stops changing *)
-  let rewrites = [ Monad_identify.left_unit ] in
+  let rewrites = [ Monad_identify.left_unit; Constructor_sinking.sink_pure ] in
   Modified.apply_while_changes
     ~f:(fun program ->
       Modified.list_fold rewrites ~init:program ~f:(fun program rewrite ->

--- a/samples/loop.kk
+++ b/samples/loop.kk
@@ -1,0 +1,7 @@
+fun loop() {
+  loop()
+}
+
+fun main() {
+  loop()
+}

--- a/test/rewriting/whole-program/bind-inlining.t/run.t
+++ b/test/rewriting/whole-program/bind-inlining.t/run.t
@@ -649,8 +649,8 @@ Then show with bind-inlining and other rewriting applied
         ((((Variable (Generated mon_51)) Pure)
           ((Variable (Generated mon_52)) Pure))
          Ctl
-         (Construct_pure
-          (Let (Variable (Generated mon_53)) Pure (Literal (Int 0))
+         (Let (Variable (Generated mon_53)) Pure (Literal (Int 0))
+          (Construct_pure
            (Operator (Variable (Generated mon_51)) (Int Greater_than)
             (Variable (Generated mon_53)))))))))
      ((Generated opt_7)
@@ -787,8 +787,8 @@ Then show with bind-inlining and other rewriting applied
              ((Generated mon_51)
               (Let (Variable (Generated mon_52)) Pure
                (Variable (Generated mon_45))
-               (Construct_pure
-                (Let (Variable (Generated mon_53)) Pure (Literal (Int 0))
+               (Let (Variable (Generated mon_53)) Pure (Literal (Int 0))
+                (Construct_pure
                  (Operator (Variable (Generated mon_51)) (Int Greater_than)
                   (Variable (Generated mon_53))))))))
             (yield_branch
@@ -984,18 +984,18 @@ Then show with bind-inlining and other rewriting applied
            (Lambda
             ((((Variable (User y)) Pure) ((Variable (Generated mon_77)) Pure))
              Ctl
-             (Construct_pure
-              (Let (Variable (Generated mon_78)) Pure (Variable (User y))
-               (Let (Variable (Generated mon_79)) Pure (Variable (User y))
+             (Let (Variable (Generated mon_78)) Pure (Variable (User y))
+              (Let (Variable (Generated mon_79)) Pure (Variable (User y))
+               (Construct_pure
                 (Operator (Variable (Generated mon_78)) (Int Times)
                  (Variable (Generated mon_79))))))))
            (Let (Variable (Generated mon_84)) Pure
             (Lambda
              ((((Variable (User x)) Pure) ((Variable (Generated mon_81)) Pure))
               Ctl
-              (Construct_pure
-               (Let (Variable (Generated mon_82)) Pure (Variable (User x))
-                (Let (Variable (Generated mon_83)) Pure (Variable (User x))
+              (Let (Variable (Generated mon_82)) Pure (Variable (User x))
+               (Let (Variable (Generated mon_83)) Pure (Variable (User x))
+                (Construct_pure
                  (Operator (Variable (Generated mon_82)) (Int Plus)
                   (Variable (Generated mon_83))))))))
             (Let (Variable (Generated mon_89)) Pure
@@ -1008,9 +1008,9 @@ Then show with bind-inlining and other rewriting applied
                  ((((Variable (User n)) Pure)
                    ((Variable (Generated mon_86)) Pure))
                   Ctl
-                  (Construct_pure
-                   (Let (Variable (Generated mon_87)) Pure (Variable (User m))
-                    (Let (Variable (Generated mon_88)) Pure (Variable (User n))
+                  (Let (Variable (Generated mon_87)) Pure (Variable (User m))
+                   (Let (Variable (Generated mon_88)) Pure (Variable (User n))
+                    (Construct_pure
                      (Operator (Variable (Generated mon_87)) (Int Minus)
                       (Variable (Generated mon_88)))))))))))
              (Let (Variable (Generated mon_90)) Pure (Literal (Int 3))
@@ -1049,9 +1049,9 @@ Then show with bind-inlining and other rewriting applied
                    ((((Variable (Language x)) Pure)
                      ((Variable (Generated mon_94)) Pure))
                     Ctl
-                    (Construct_pure
-                     (Let (Variable (Generated mon_95)) Pure
-                      (Variable (Language x))
+                    (Let (Variable (Generated mon_95)) Pure
+                     (Variable (Language x))
+                     (Construct_pure
                       (Impure_built_in
                        (Impure_print_int (value (Variable (Generated mon_95)))
                         (newline false)))))))))
@@ -1066,9 +1066,9 @@ Then show with bind-inlining and other rewriting applied
                    ((((Variable (Language x)) Pure)
                      ((Variable (Generated mon_97)) Pure))
                     Ctl
-                    (Construct_pure
-                     (Let (Variable (Generated mon_98)) Pure
-                      (Variable (Language x))
+                    (Let (Variable (Generated mon_98)) Pure
+                     (Variable (Language x))
+                     (Construct_pure
                       (Impure_built_in
                        (Impure_print_int (value (Variable (Generated mon_98)))
                         (newline true)))))))))

--- a/test/rewriting/whole-program/loop.t/loop.kk
+++ b/test/rewriting/whole-program/loop.t/loop.kk
@@ -1,0 +1,9 @@
+fun loop(n) {
+  if n == 0
+  then ()
+  else loop(n - 1)
+}
+
+fun main() {
+  loop(1000)
+}

--- a/test/rewriting/whole-program/loop.t/run.t
+++ b/test/rewriting/whole-program/loop.t/run.t
@@ -1,0 +1,596 @@
+Show the generated code for a program with many binds
+  $ export PROJECT_ROOT=../../../..
+
+First show without any rewriting optimisations
+  $ ../compile.sh loop.kk -dump-eps
+  ((effect_declarations
+    (((name console)
+      (operations
+       ((User print-int) (User println) (User println-int) (User read-int))))))
+   (fun_declarations
+    (((Language bind)
+      ((((Variable (Generated mon_0)) Ctl) ((Variable (Generated mon_1)) Pure)
+        ((Variable (Generated mon_2)) Pure))
+       Ctl
+       (Match_ctl (subject (Variable (Generated mon_0)))
+        (pure_branch
+         ((Generated mon_3)
+          (Application (Variable (Generated mon_2))
+           (((Variable (Generated mon_3)) Pure)
+            ((Variable (Generated mon_1)) Pure))
+           Ctl)))
+        (yield_branch
+         ((Generated mon_4) (Generated mon_5) (Generated mon_6)
+          (Construct_yield (marker (Variable (Generated mon_4)))
+           (op_clause (Variable (Generated mon_5)))
+           (resumption
+            (Lambda
+             ((((Variable (Generated mon_7)) Pure)
+               ((Variable (Generated mon_8)) Pure))
+              Ctl
+              (Application (Variable (Language bind))
+               (((Application (Variable (Generated mon_6))
+                  (((Variable (Generated mon_7)) Pure)
+                   ((Variable (Generated mon_8)) Pure))
+                  Ctl)
+                 Ctl)
+                ((Variable (Generated mon_8)) Pure)
+                ((Variable (Generated mon_2)) Pure))
+               Ctl))))))))))
+     ((Language prompt)
+      ((((Variable (Generated mon_9)) Pure)
+        ((Variable (Generated mon_10)) Pure)
+        ((Variable (Generated mon_11)) Pure)
+        ((Variable (Generated mon_12)) Pure)
+        ((Variable (Generated mon_13)) Pure))
+       Ctl
+       (Match_ctl
+        (subject
+         (Application (Variable (Generated mon_12))
+          (((Cons_evidence_vector (label (Variable (Generated mon_9)))
+             (marker (Variable (Generated mon_10)))
+             (handler (Variable (Generated mon_11)))
+             (handler_site_vector (Variable (Generated mon_13)))
+             (vector_tail (Variable (Generated mon_13))))
+            Pure))
+          Ctl))
+        (pure_branch
+         ((Generated mon_14) (Construct_pure (Variable (Generated mon_14)))))
+        (yield_branch
+         ((Generated mon_15) (Generated mon_16) (Generated mon_17)
+          (If_then_else
+           (Markers_equal (Variable (Generated mon_10))
+            (Variable (Generated mon_15)))
+           (Application (Variable (Generated mon_16))
+            (((Lambda
+               ((((Variable (Generated mon_18)) Pure)
+                 ((Variable (Generated mon_19)) Pure))
+                Ctl
+                (Application (Variable (Language prompt))
+                 (((Variable (Generated mon_9)) Pure)
+                  ((Variable (Generated mon_10)) Pure)
+                  ((Variable (Generated mon_11)) Pure)
+                  ((Lambda
+                    ((((Variable (Generated mon_20)) Pure)) Ctl
+                     (Application (Variable (Generated mon_17))
+                      (((Variable (Generated mon_18)) Pure)
+                       ((Variable (Generated mon_20)) Pure))
+                      Ctl)))
+                   Pure)
+                  ((Variable (Generated mon_19)) Pure))
+                 Ctl)))
+              Pure)
+             ((Variable (Generated mon_13)) Pure))
+            Ctl)
+           (Construct_yield (marker (Variable (Generated mon_15)))
+            (op_clause (Variable (Generated mon_16)))
+            (resumption
+             (Lambda
+              ((((Variable (Generated mon_18)) Pure)
+                ((Variable (Generated mon_19)) Pure))
+               Ctl
+               (Application (Variable (Language prompt))
+                (((Variable (Generated mon_9)) Pure)
+                 ((Variable (Generated mon_10)) Pure)
+                 ((Variable (Generated mon_11)) Pure)
+                 ((Lambda
+                   ((((Variable (Generated mon_20)) Pure)) Ctl
+                    (Application (Variable (Generated mon_17))
+                     (((Variable (Generated mon_18)) Pure)
+                      ((Variable (Generated mon_20)) Pure))
+                     Ctl)))
+                  Pure)
+                 ((Variable (Generated mon_19)) Pure))
+                Ctl)))))))))))
+     ((Language handler)
+      ((((Variable (Generated mon_21)) Pure)
+        ((Variable (Generated mon_22)) Pure))
+       Pure
+       (Lambda
+        ((((Variable (Generated mon_23)) Pure)
+          ((Variable (Generated mon_24)) Pure))
+         Ctl
+         (Application (Variable (Language prompt))
+          (((Variable (Generated mon_21)) Pure) (Fresh_marker Pure)
+           ((Variable (Generated mon_22)) Pure)
+           ((Variable (Generated mon_23)) Pure)
+           ((Variable (Generated mon_24)) Pure))
+          Ctl)))))
+     ((Language under)
+      ((((Variable (Generated mon_25)) Pure)
+        ((Variable (Generated mon_26)) Pure)
+        ((Variable (Generated mon_27)) Pure)
+        ((Variable (Generated mon_28)) Pure))
+       Ctl
+       (Match_ctl
+        (subject
+         (Application (Variable (Generated mon_28))
+          (((Variable (Generated mon_27)) Pure)
+           ((Variable (Generated mon_26)) Pure))
+          Ctl))
+        (pure_branch
+         ((Generated mon_29) (Construct_pure (Variable (Generated mon_29)))))
+        (yield_branch
+         ((Generated mon_30) (Generated mon_31) (Generated mon_32)
+          (Construct_yield (marker (Variable (Generated mon_30)))
+           (op_clause (Variable (Generated mon_31)))
+           (resumption
+            (Lambda
+             ((((Variable (Generated mon_33)) Pure)
+               ((Variable (Generated mon_34)) Pure))
+              Ctl
+              (Application (Variable (Language under))
+               (((Variable (Generated mon_25)) Pure)
+                ((Get_evidence_handler_site_vector
+                  (Lookup_evidence (label (Variable (Generated mon_25)))
+                   (vector (Variable (Generated mon_34)))))
+                 Pure)
+                ((Variable (Generated mon_33)) Pure)
+                ((Variable (Generated mon_32)) Pure))
+               Ctl))))))))))
+     ((Language perform)
+      ((((Variable (Generated mon_35)) Pure)
+        ((Variable (Generated mon_36)) Pure))
+       Pure
+       (Lambda
+        ((((Variable (Generated mon_37)) Pure)
+          ((Variable (Generated mon_38)) Pure))
+         Ctl
+         (Match_op
+          (subject
+           (Application (Variable (Generated mon_36))
+            (((Get_evidence_handler
+               (Lookup_evidence (label (Variable (Generated mon_35)))
+                (vector (Variable (Generated mon_38)))))
+              Pure))
+            Pure))
+          (normal_branch
+           ((Generated mon_39)
+            (Construct_yield
+             (marker
+              (Get_evidence_marker
+               (Lookup_evidence (label (Variable (Generated mon_35)))
+                (vector (Variable (Generated mon_38))))))
+             (op_clause
+              (Lambda
+               ((((Variable (Generated mon_42)) Pure)
+                 ((Variable (Generated mon_43)) Pure))
+                Ctl
+                (Application (Variable (Generated mon_39))
+                 (((Variable (Generated mon_37)) Pure)
+                  ((Variable (Generated mon_42)) Pure)
+                  ((Variable (Generated mon_43)) Pure))
+                 Ctl))))
+             (resumption
+              (Lambda
+               ((((Variable (Generated mon_40)) Pure)
+                 ((Variable (Generated mon_41)) Pure))
+                Ctl (Construct_pure (Variable (Generated mon_40)))))))))
+          (tail_branch
+           ((Generated mon_44)
+            (Application (Variable (Language under))
+             (((Variable (Generated mon_35)) Pure)
+              ((Get_evidence_handler_site_vector
+                (Lookup_evidence (label (Variable (Generated mon_35)))
+                 (vector (Variable (Generated mon_38)))))
+               Pure)
+              ((Variable (Generated mon_37)) Pure)
+              ((Variable (Generated mon_44)) Pure))
+             Ctl))))))))
+     ((User loop)
+      ((((Variable (User n)) Pure) ((Variable (Generated mon_45)) Pure)) Ctl
+       (Construct_pure
+        (Let (Variable (Generated mon_48)) Pure
+         (Let (Variable (Generated mon_46)) Pure (Variable (User n))
+          (Let (Variable (Generated mon_47)) Pure (Literal (Int 0))
+           (Operator (Variable (Generated mon_46)) (Int Equals)
+            (Variable (Generated mon_47)))))
+         (If_then_else (Variable (Generated mon_48)) (Literal Unit)
+          (Let (Variable (Generated mon_49)) Pure (Variable (User loop))
+           (Let (Variable (Generated mon_52)) Pure
+            (Let (Variable (Generated mon_50)) Pure (Variable (User n))
+             (Let (Variable (Generated mon_51)) Pure (Literal (Int 1))
+              (Operator (Variable (Generated mon_50)) (Int Minus)
+               (Variable (Generated mon_51)))))
+            (Match_ctl_pure
+             (subject
+              (Application (Variable (Generated mon_49))
+               (((Variable (Generated mon_52)) Pure)
+                ((Variable (Generated mon_45)) Pure))
+               Ctl))
+             (pure_branch ((Generated mon_53) (Variable (Generated mon_53))))))))))))
+     ((User main)
+      ((((Variable (Generated mon_54)) Pure)) Ctl
+       (Construct_pure
+        (Let (Variable (Generated mon_55)) Pure (Variable (User loop))
+         (Let (Variable (Generated mon_56)) Pure (Literal (Int 1000))
+          (Match_ctl_pure
+           (subject
+            (Application (Variable (Generated mon_55))
+             (((Variable (Generated mon_56)) Pure)
+              ((Variable (Generated mon_54)) Pure))
+             Ctl))
+           (pure_branch ((Generated mon_57) (Variable (Generated mon_57))))))))))
+     ((Language main)
+      ((((Variable (Generated mon_58)) Pure)) Ctl
+       (Application (Variable (Language bind))
+        (((Let (Variable (Generated mon_65)) Pure
+           (Application (Variable (Language handler))
+            (((Effect_label console) Pure)
+             ((Construct_handler (handled_effect console)
+               (operation_clauses
+                (((User print-int)
+                  (Construct_op_tail
+                   (Lambda
+                    ((((Variable (Language x)) Pure)
+                      ((Variable (Generated mon_59)) Pure))
+                     Ctl
+                     (Construct_pure
+                      (Let (Variable (Generated mon_60)) Pure
+                       (Variable (Language x))
+                       (Impure_built_in
+                        (Impure_print_int (value (Variable (Generated mon_60)))
+                         (newline false)))))))))
+                 ((User println)
+                  (Construct_op_tail
+                   (Lambda
+                    (((Wildcard Pure) ((Variable (Generated mon_61)) Pure)) Ctl
+                     (Construct_pure (Impure_built_in Impure_println))))))
+                 ((User println-int)
+                  (Construct_op_tail
+                   (Lambda
+                    ((((Variable (Language x)) Pure)
+                      ((Variable (Generated mon_62)) Pure))
+                     Ctl
+                     (Construct_pure
+                      (Let (Variable (Generated mon_63)) Pure
+                       (Variable (Language x))
+                       (Impure_built_in
+                        (Impure_print_int (value (Variable (Generated mon_63)))
+                         (newline true)))))))))
+                 ((User read-int)
+                  (Construct_op_tail
+                   (Lambda
+                    (((Wildcard Pure) ((Variable (Generated mon_64)) Pure)) Ctl
+                     (Construct_pure (Impure_built_in Impure_read_int)))))))))
+              Pure))
+            Pure)
+           (Let (Variable (Generated mon_66)) Pure (Variable (User main))
+            (Application (Variable (Generated mon_65))
+             (((Variable (Generated mon_66)) Pure)
+              ((Variable (Generated mon_58)) Pure))
+             Ctl)))
+          Ctl)
+         ((Variable (Generated mon_58)) Pure)
+         ((Lambda
+           ((((Variable (Generated mon_67)) Pure)
+             ((Variable (Generated mon_68)) Pure))
+            Ctl (Construct_pure (Literal Unit))))
+          Pure))
+        Ctl)))))
+   (entry_expr
+    (Application (Variable (Language main)) ((Nil_evidence_vector Pure)) Ctl)))
+
+Then show with bind-inlining and other rewriting applied
+  $ ../compile.sh loop.kk -dump-eps -optimise
+  ((effect_declarations
+    (((name console)
+      (operations
+       ((User print-int) (User println) (User println-int) (User read-int))))))
+   (fun_declarations
+    (((Language bind)
+      ((((Variable (Generated mon_0)) Ctl) ((Variable (Generated mon_1)) Pure)
+        ((Variable (Generated mon_2)) Pure))
+       Ctl
+       (Match_ctl (subject (Variable (Generated mon_0)))
+        (pure_branch
+         ((Generated mon_3)
+          (Application (Variable (Generated mon_2))
+           (((Variable (Generated mon_3)) Pure)
+            ((Variable (Generated mon_1)) Pure))
+           Ctl)))
+        (yield_branch
+         ((Generated mon_4) (Generated mon_5) (Generated mon_6)
+          (Construct_yield (marker (Variable (Generated mon_4)))
+           (op_clause (Variable (Generated mon_5)))
+           (resumption
+            (Lambda
+             ((((Variable (Generated mon_7)) Pure)
+               ((Variable (Generated mon_8)) Pure))
+              Ctl
+              (Application (Variable (Language bind))
+               (((Application (Variable (Generated mon_6))
+                  (((Variable (Generated mon_7)) Pure)
+                   ((Variable (Generated mon_8)) Pure))
+                  Ctl)
+                 Ctl)
+                ((Variable (Generated mon_8)) Pure)
+                ((Variable (Generated mon_2)) Pure))
+               Ctl))))))))))
+     ((Language prompt)
+      ((((Variable (Generated mon_9)) Pure)
+        ((Variable (Generated mon_10)) Pure)
+        ((Variable (Generated mon_11)) Pure)
+        ((Variable (Generated mon_12)) Pure)
+        ((Variable (Generated mon_13)) Pure))
+       Ctl
+       (Match_ctl
+        (subject
+         (Application (Variable (Generated mon_12))
+          (((Cons_evidence_vector (label (Variable (Generated mon_9)))
+             (marker (Variable (Generated mon_10)))
+             (handler (Variable (Generated mon_11)))
+             (handler_site_vector (Variable (Generated mon_13)))
+             (vector_tail (Variable (Generated mon_13))))
+            Pure))
+          Ctl))
+        (pure_branch
+         ((Generated mon_14) (Construct_pure (Variable (Generated mon_14)))))
+        (yield_branch
+         ((Generated mon_15) (Generated mon_16) (Generated mon_17)
+          (If_then_else
+           (Markers_equal (Variable (Generated mon_10))
+            (Variable (Generated mon_15)))
+           (Application (Variable (Generated mon_16))
+            (((Lambda
+               ((((Variable (Generated mon_18)) Pure)
+                 ((Variable (Generated mon_19)) Pure))
+                Ctl
+                (Application (Variable (Language prompt))
+                 (((Variable (Generated mon_9)) Pure)
+                  ((Variable (Generated mon_10)) Pure)
+                  ((Variable (Generated mon_11)) Pure)
+                  ((Lambda
+                    ((((Variable (Generated mon_20)) Pure)) Ctl
+                     (Application (Variable (Generated mon_17))
+                      (((Variable (Generated mon_18)) Pure)
+                       ((Variable (Generated mon_20)) Pure))
+                      Ctl)))
+                   Pure)
+                  ((Variable (Generated mon_19)) Pure))
+                 Ctl)))
+              Pure)
+             ((Variable (Generated mon_13)) Pure))
+            Ctl)
+           (Construct_yield (marker (Variable (Generated mon_15)))
+            (op_clause (Variable (Generated mon_16)))
+            (resumption
+             (Lambda
+              ((((Variable (Generated mon_18)) Pure)
+                ((Variable (Generated mon_19)) Pure))
+               Ctl
+               (Application (Variable (Language prompt))
+                (((Variable (Generated mon_9)) Pure)
+                 ((Variable (Generated mon_10)) Pure)
+                 ((Variable (Generated mon_11)) Pure)
+                 ((Lambda
+                   ((((Variable (Generated mon_20)) Pure)) Ctl
+                    (Application (Variable (Generated mon_17))
+                     (((Variable (Generated mon_18)) Pure)
+                      ((Variable (Generated mon_20)) Pure))
+                     Ctl)))
+                  Pure)
+                 ((Variable (Generated mon_19)) Pure))
+                Ctl)))))))))))
+     ((Language handler)
+      ((((Variable (Generated mon_21)) Pure)
+        ((Variable (Generated mon_22)) Pure))
+       Pure
+       (Lambda
+        ((((Variable (Generated mon_23)) Pure)
+          ((Variable (Generated mon_24)) Pure))
+         Ctl
+         (Application (Variable (Language prompt))
+          (((Variable (Generated mon_21)) Pure) (Fresh_marker Pure)
+           ((Variable (Generated mon_22)) Pure)
+           ((Variable (Generated mon_23)) Pure)
+           ((Variable (Generated mon_24)) Pure))
+          Ctl)))))
+     ((Language under)
+      ((((Variable (Generated mon_25)) Pure)
+        ((Variable (Generated mon_26)) Pure)
+        ((Variable (Generated mon_27)) Pure)
+        ((Variable (Generated mon_28)) Pure))
+       Ctl
+       (Match_ctl
+        (subject
+         (Application (Variable (Generated mon_28))
+          (((Variable (Generated mon_27)) Pure)
+           ((Variable (Generated mon_26)) Pure))
+          Ctl))
+        (pure_branch
+         ((Generated mon_29) (Construct_pure (Variable (Generated mon_29)))))
+        (yield_branch
+         ((Generated mon_30) (Generated mon_31) (Generated mon_32)
+          (Construct_yield (marker (Variable (Generated mon_30)))
+           (op_clause (Variable (Generated mon_31)))
+           (resumption
+            (Lambda
+             ((((Variable (Generated mon_33)) Pure)
+               ((Variable (Generated mon_34)) Pure))
+              Ctl
+              (Application (Variable (Language under))
+               (((Variable (Generated mon_25)) Pure)
+                ((Get_evidence_handler_site_vector
+                  (Lookup_evidence (label (Variable (Generated mon_25)))
+                   (vector (Variable (Generated mon_34)))))
+                 Pure)
+                ((Variable (Generated mon_33)) Pure)
+                ((Variable (Generated mon_32)) Pure))
+               Ctl))))))))))
+     ((Language perform)
+      ((((Variable (Generated mon_35)) Pure)
+        ((Variable (Generated mon_36)) Pure))
+       Pure
+       (Lambda
+        ((((Variable (Generated mon_37)) Pure)
+          ((Variable (Generated mon_38)) Pure))
+         Ctl
+         (Match_op
+          (subject
+           (Application (Variable (Generated mon_36))
+            (((Get_evidence_handler
+               (Lookup_evidence (label (Variable (Generated mon_35)))
+                (vector (Variable (Generated mon_38)))))
+              Pure))
+            Pure))
+          (normal_branch
+           ((Generated mon_39)
+            (Construct_yield
+             (marker
+              (Get_evidence_marker
+               (Lookup_evidence (label (Variable (Generated mon_35)))
+                (vector (Variable (Generated mon_38))))))
+             (op_clause
+              (Lambda
+               ((((Variable (Generated mon_42)) Pure)
+                 ((Variable (Generated mon_43)) Pure))
+                Ctl
+                (Application (Variable (Generated mon_39))
+                 (((Variable (Generated mon_37)) Pure)
+                  ((Variable (Generated mon_42)) Pure)
+                  ((Variable (Generated mon_43)) Pure))
+                 Ctl))))
+             (resumption
+              (Lambda
+               ((((Variable (Generated mon_40)) Pure)
+                 ((Variable (Generated mon_41)) Pure))
+                Ctl (Construct_pure (Variable (Generated mon_40)))))))))
+          (tail_branch
+           ((Generated mon_44)
+            (Application (Variable (Language under))
+             (((Variable (Generated mon_35)) Pure)
+              ((Get_evidence_handler_site_vector
+                (Lookup_evidence (label (Variable (Generated mon_35)))
+                 (vector (Variable (Generated mon_38)))))
+               Pure)
+              ((Variable (Generated mon_37)) Pure)
+              ((Variable (Generated mon_44)) Pure))
+             Ctl))))))))
+     ((User loop)
+      ((((Variable (User n)) Pure) ((Variable (Generated mon_45)) Pure)) Ctl
+       (Let (Variable (Generated mon_48)) Pure
+        (Let (Variable (Generated mon_46)) Pure (Variable (User n))
+         (Let (Variable (Generated mon_47)) Pure (Literal (Int 0))
+          (Operator (Variable (Generated mon_46)) (Int Equals)
+           (Variable (Generated mon_47)))))
+        (If_then_else (Variable (Generated mon_48))
+         (Construct_pure (Literal Unit))
+         (Let (Variable (Generated mon_49)) Pure (Variable (User loop))
+          (Let (Variable (Generated mon_52)) Pure
+           (Let (Variable (Generated mon_50)) Pure (Variable (User n))
+            (Let (Variable (Generated mon_51)) Pure (Literal (Int 1))
+             (Operator (Variable (Generated mon_50)) (Int Minus)
+              (Variable (Generated mon_51)))))
+           (Application (Variable (Generated mon_49))
+            (((Variable (Generated mon_52)) Pure)
+             ((Variable (Generated mon_45)) Pure))
+            Ctl)))))))
+     ((User main)
+      ((((Variable (Generated mon_54)) Pure)) Ctl
+       (Let (Variable (Generated mon_55)) Pure (Variable (User loop))
+        (Let (Variable (Generated mon_56)) Pure (Literal (Int 1000))
+         (Application (Variable (Generated mon_55))
+          (((Variable (Generated mon_56)) Pure)
+           ((Variable (Generated mon_54)) Pure))
+          Ctl)))))
+     ((Generated opt_0)
+      (() Pure
+       (Lambda
+        ((((Variable (Generated mon_67)) Pure)
+          ((Variable (Generated mon_68)) Pure))
+         Ctl (Construct_pure (Literal Unit))))))
+     ((Language main)
+      ((((Variable (Generated mon_58)) Pure)) Ctl
+       (Match_ctl
+        (subject
+         (Let (Variable (Generated mon_65)) Pure
+          (Application (Variable (Language handler))
+           (((Effect_label console) Pure)
+            ((Construct_handler (handled_effect console)
+              (operation_clauses
+               (((User print-int)
+                 (Construct_op_tail
+                  (Lambda
+                   ((((Variable (Language x)) Pure)
+                     ((Variable (Generated mon_59)) Pure))
+                    Ctl
+                    (Let (Variable (Generated mon_60)) Pure
+                     (Variable (Language x))
+                     (Construct_pure
+                      (Impure_built_in
+                       (Impure_print_int (value (Variable (Generated mon_60)))
+                        (newline false)))))))))
+                ((User println)
+                 (Construct_op_tail
+                  (Lambda
+                   (((Wildcard Pure) ((Variable (Generated mon_61)) Pure)) Ctl
+                    (Construct_pure (Impure_built_in Impure_println))))))
+                ((User println-int)
+                 (Construct_op_tail
+                  (Lambda
+                   ((((Variable (Language x)) Pure)
+                     ((Variable (Generated mon_62)) Pure))
+                    Ctl
+                    (Let (Variable (Generated mon_63)) Pure
+                     (Variable (Language x))
+                     (Construct_pure
+                      (Impure_built_in
+                       (Impure_print_int (value (Variable (Generated mon_63)))
+                        (newline true)))))))))
+                ((User read-int)
+                 (Construct_op_tail
+                  (Lambda
+                   (((Wildcard Pure) ((Variable (Generated mon_64)) Pure)) Ctl
+                    (Construct_pure (Impure_built_in Impure_read_int)))))))))
+             Pure))
+           Pure)
+          (Let (Variable (Generated mon_66)) Pure (Variable (User main))
+           (Application (Variable (Generated mon_65))
+            (((Variable (Generated mon_66)) Pure)
+             ((Variable (Generated mon_58)) Pure))
+            Ctl))))
+        (pure_branch
+         ((Generated mon_67)
+          (Let (Variable (Generated mon_68)) Pure (Variable (Generated mon_58))
+           (Construct_pure (Literal Unit)))))
+        (yield_branch
+         ((Generated opt_1) (Generated opt_2) (Generated opt_3)
+          (Construct_yield (marker (Variable (Generated opt_1)))
+           (op_clause (Variable (Generated opt_2)))
+           (resumption
+            (Lambda
+             ((((Variable (Generated opt_4)) Pure)
+               ((Variable (Generated opt_5)) Pure))
+              Ctl
+              (Application (Variable (Language bind))
+               (((Application (Variable (Generated opt_3))
+                  (((Variable (Generated opt_4)) Pure)
+                   ((Variable (Generated opt_5)) Pure))
+                  Ctl)
+                 Ctl)
+                ((Variable (Generated opt_5)) Pure)
+                ((Application (Variable (Generated opt_0)) () Pure) Pure))
+               Ctl))))))))))))
+   (entry_expr
+    (Application (Variable (Language main)) ((Nil_evidence_vector Pure)) Ctl)))

--- a/test/semantics/tail-recursion.t/run.t
+++ b/test/semantics/tail-recursion.t/run.t
@@ -1,0 +1,9 @@
+Run a tail-recursive loop a large number of iterations
+  $ cat >in.txt <<EOF
+  > 10000000
+  > EOF
+
+  $ export PROJECT_ROOT=../../..
+  $ ../compile.sh tail-recursive.kk
+  $ ./tail-recursive <in.txt
+  input> 

--- a/test/semantics/tail-recursion.t/tail-recursive.kk
+++ b/test/semantics/tail-recursion.t/tail-recursive.kk
@@ -1,0 +1,9 @@
+fun loop(n) {
+  if n == 0
+  then ()
+  else loop(n - 1)
+}
+
+fun main() {
+  loop(read-int(()))
+}


### PR DESCRIPTION
In some cases the optimised pure-function calling convention prevents tail-call optimisation by inserting a `match` and wrapping the whole function body in `Pure`. Add general-purpose optimisation rewrites to address this:

- sink `Pure` constructors down to tail position.
- remove `match` expressions where the cases each just reconstruct the subject.