### PR TITLE
Include location information on type errors

### DIFF
--- a/lib/phases/02-subtyping-inference/constraints.mli
+++ b/lib/phases/02-subtyping-inference/constraints.mli
@@ -12,12 +12,14 @@ val constrain_type_at_most
   :  t
   -> Type.Mono.t
   -> Type.Mono.t
+  -> location:Metavariables.Location.t
   -> unit Or_static_error.t
 
 val constrain_effect_at_most
   :  t
   -> Effect.t
   -> Effect.t
+  -> location:Metavariables.Location.t
   -> unit Or_static_error.t
 
 val get_type_bounds : t -> Type.Metavariable.t -> Type.Mono.t Bounds.t option

--- a/lib/phases/02-subtyping-inference/metavariables.ml
+++ b/lib/phases/02-subtyping-inference/metavariables.ml
@@ -12,6 +12,7 @@ module Location = struct
     | Handler_result of Minimal_syntax.Expr.handler
     | List_element of t
     | Instantiation of t
+    | Entry_point
   [@@deriving sexp_of]
 end
 

--- a/lib/phases/02-subtyping-inference/metavariables.mli
+++ b/lib/phases/02-subtyping-inference/metavariables.mli
@@ -17,6 +17,7 @@ module Location : sig
     *)
     | List_element of t (** for a type `list<a>` this is the element type `a` *)
     | Instantiation of t
+    | Entry_point
   [@@deriving sexp_of]
 end
 

--- a/test/inference/test_inference_invalid.ml
+++ b/test/inference/test_inference_invalid.ml
@@ -41,8 +41,19 @@ let%expect_test
     (Error
      ((kind Type_error)
       (error
-       (("error when expanding constraint" (type_lo (Metavariable tm3))
-         (type_hi (Arrow ((Tuple ())) (Metavariable em5) (Metavariable tm4))))
+       (("error when expanding constraint"
+         ((type_lo (Metavariable tm3))
+          (type_hi (Arrow ((Tuple ())) (Metavariable em5) (Metavariable tm4))))
+         (location
+          (Application
+           (Application
+            (Value
+             (Lambda
+              (((Variable (User x)))
+               (Application (Value (Variable (User x)))
+                ((Value (Variable (User x))))))))
+            ((Value (Lambda (((Variable (User y))) (Value (Variable (User y))))))))
+           ((Tuple_construction ())))))
         ("type error: cannot relate" (type_lo (Tuple ()))
          (type_hi (Arrow ((Tuple ())) (Metavariable em5) (Metavariable tm4))))))
       (location ())))

--- a/test/soundness/faulty/static-handler.t/run.t
+++ b/test/soundness/faulty/static-handler.t/run.t
@@ -2,7 +2,8 @@ Attempting to perform an effect not under a (dynamic) handler,
 but within a function _defined_ under a handler (statically)
   $ koka-zero check static-handler.kk
   type error: (("error when expanding constraint"
-    (type_lo (Arrow () (Metavariable em25) (Tuple ())))
-    (type_hi (Arrow () (Labels ()) (Tuple ()))))
+    ((type_lo (Arrow () (Metavariable em25) (Tuple ())))
+     (type_hi (Arrow () (Labels ()) (Tuple ()))))
+    (location Entry_point))
    ("constraint doesn't hold" (labels (exn)) (expected_at_most (console))))
   [1]

--- a/test/soundness/faulty/unhandled-effect.t/run.t
+++ b/test/soundness/faulty/unhandled-effect.t/run.t
@@ -1,7 +1,8 @@
 Every operation requires an enclosing handler
   $ koka-zero check unhandled-effect.kk
   type error: (("error when expanding constraint"
-    (type_lo (Arrow () (Metavariable em10) (Tuple ())))
-    (type_hi (Arrow () (Labels ()) (Tuple ()))))
+    ((type_lo (Arrow () (Metavariable em10) (Tuple ())))
+     (type_hi (Arrow () (Labels ()) (Tuple ()))))
+    (location Entry_point))
    ("constraint doesn't hold" (labels (read)) (expected_at_most (console))))
   [1]

--- a/test/soundness/faulty/val-monomorphic.t/run.t
+++ b/test/soundness/faulty/val-monomorphic.t/run.t
@@ -1,7 +1,9 @@
 Val bindings are not polymorphic
   $ koka-zero check val-monomorphic.kk
   type error: (("error when expanding constraint"
-    (type_lo (Arrow ((Metavariable tm1)) (Labels ()) (Metavariable tm1)))
-    (type_hi (Arrow ((Primitive Bool)) (Metavariable em3) (Metavariable tm3))))
+    ((type_lo (Arrow ((Metavariable tm1)) (Labels ()) (Metavariable tm1)))
+     (type_hi (Arrow ((Primitive Bool)) (Metavariable em3) (Metavariable tm3))))
+    (location
+     (Application (Value (Variable (User id))) ((Value (Literal (Bool true)))))))
    ("inconsistent types" (p Bool) (p' Int)))
   [1]


### PR DESCRIPTION
Whenever we solve a constraint, track the initial expression it came from, to surface in the error message.

This is not as useful as tracking actual character positions in the source file, but it's still an improvement.