### PR TITLE
Hint tail-calls to llvm

### DIFF
--- a/lib/phases/04-code-generation/calling_convention.ml
+++ b/lib/phases/04-code-generation/calling_convention.ml
@@ -165,12 +165,16 @@ let compile_call_common
     let%map return_type = return_lltype return_type in
     Llvm.function_type return_type (Array.of_list arg_types)
   in
-  Codegen.use_builder
-    (Llvm.build_call
-       function_type
-       code_pointer
-       (Array.of_list arg_values)
-       "result")
+  let%map call_instr =
+    Codegen.use_builder
+      (Llvm.build_call
+         function_type
+         code_pointer
+         (Array.of_list arg_values)
+         "result")
+  in
+  Llvm.set_tail_call true call_instr;
+  call_instr
 ;;
 
 let compile_call


### PR DESCRIPTION
Generate `tail call` rather than just `call` for calls in tail position. This helps to ensure tail-call-optimisation does occur.

In at least one previous example this wasn't performed, and instead callee-saved registers were restored after the call.